### PR TITLE
Add speedrun script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ uv run python train.py --task dna       # DNA classification
 uv run python train.py --task ts        # time series forecasting
 ```
 
+Or reproduce the current best result in one shot:
+
+```bash
+bash runs/speedrun.sh    # ~2.19 val_bpb in 84s on M1 Max
+```
+
 ## Generation
 
 Train a model, then generate text from it. Runs in recurrent mode: constant memory, constant cost per token. No KV cache.

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Speedrun: reproduce the current best nanostate result.
+#
+# Byte-level TinyShakespeare, M1 Max, ~80 seconds.
+# Target: 2.18 val_bpb (HiPPO-LegS init, gated blocks, cosine LR)
+#
+# Usage:
+#   bash runs/speedrun.sh              # train + eval
+#   bash runs/speedrun.sh --eval-only  # eval existing checkpoint
+set -euo pipefail
+
+CHECKPOINT="checkpoints/speedrun"
+
+if [[ "${1:-}" != "--eval-only" ]]; then
+    echo "=== Speedrun: byte-level TinyShakespeare ==="
+    echo "Target: ~2.18 val_bpb | d=384, L=4, N=64 | ~4.3M params"
+    echo ""
+
+    # Warmup (compiles kernels, doesn't count toward time)
+    uv run python train.py --task lm --steps 10 > /dev/null 2>&1
+
+    # Train
+    uv run python train.py \
+        --task lm \
+        --steps 1000 \
+        --lr 5e-4 \
+        --batch 32 \
+        --save "$CHECKPOINT"
+
+    echo ""
+fi
+
+# Eval
+echo "=== Evaluation ==="
+uv run python eval.py "$CHECKPOINT" --steps 100
+
+# Generate sample
+echo ""
+echo "=== Sample generation ==="
+uv run python generate.py "$CHECKPOINT" --prompt "ROMEO: " --tokens 200
+echo ""


### PR DESCRIPTION
## Summary
- `runs/speedrun.sh` reproduces the current best result in one shot
- Trains byte-level TinyShakespeare to ~2.19 val_bpb in ~84s on M1 Max
- Warmup, train, eval, and sample generation in a single script
- `--eval-only` flag to skip training and eval an existing checkpoint
- README updated with speedrun usage

## Test plan
- [x] `bash runs/speedrun.sh` runs end-to-end (warmup → train → eval → generate)
- [x] Hits ~2.19 val_bpb (target: 2.18, variance from random init)
- [x] `--eval-only` skips training

🤖 Generated with [Claude Code](https://claude.com/claude-code)