### PR TITLE
Add inference benchmark and infinite context demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,32 @@ uv run python generate.py checkpoints/lm --temp 0.7 --top-k 20 --tokens 1000
 
 The inference state is a fixed-size vector (d_inner x state_dim x n_layers x 4 bytes). For the default model that's 768KB. Generating the millionth token costs the same as the first.
 
+## Inference benchmark
+
+Measure tokens/sec at different context depths to prove the SSM advantage: constant cost per token.
+
+```bash
+uv run python benchmark.py checkpoints/lm
+```
+
+```
+After      0 tokens of context: 1,071 tok/s
+After  1,000 tokens of context: 1,133 tok/s
+After 10,000 tokens of context: 1,118 tok/s
+```
+
+A transformer's KV cache would use ~117 MB at 10K tokens. The SSM state is always 768 KB.
+
+## Infinite context
+
+Stream an entire book through the model with constant memory. Then generate a continuation from the final state.
+
+```bash
+uv run python infinite_context.py checkpoints/lm --file data/shakespeare.txt --generate 200
+```
+
+The state vector never grows — processing token 1,000,000 costs the same as token 1.
+
 ## Evaluation
 
 Evaluate a checkpoint on its validation set or run standardized benchmarks. Prints results as JSON.

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,104 @@
+"""Benchmark recurrent inference speed.
+
+Measures tokens/sec at different context depths to demonstrate the SSM
+advantage: constant cost per token regardless of sequence length.
+
+A transformer's KV cache grows linearly, so token 10,000 costs more than
+token 100. An SSM's fixed state vector means both cost the same.
+
+Usage:
+  python benchmark.py checkpoints/lm
+  python benchmark.py checkpoints/lm_tok --tokens 500
+"""
+
+import argparse
+import time
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from engine import RecurrentState, load_model
+
+
+def benchmark_at_position(state, start_token, warmup=10, measure=200):
+    """Generate tokens and measure speed.
+
+    Returns tokens/sec averaged over `measure` tokens.
+    """
+    token = start_token
+    # Warmup
+    for _ in range(warmup):
+        logits = state.step(token)
+        token = mx.argmax(logits).item()
+
+    # Measure
+    t0 = time.time()
+    for _ in range(measure):
+        logits = state.step(token)
+        token = mx.argmax(logits).item()
+    elapsed = time.time() - t0
+    return measure / elapsed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark recurrent inference")
+    parser.add_argument("checkpoint", help="Path to checkpoint directory")
+    parser.add_argument("--tokens", type=int, default=200, help="Tokens to measure per position")
+    args = parser.parse_args()
+
+    model, config = load_model(args.checkpoint)
+    task = config["task"]
+    d, n_layers, n = config["d_model"], config["n_layers"], config["state_dim"]
+    n_params = sum(x.size for _, x in nn.utils.tree_flatten(model.parameters()))
+    mlp_ratio = config.get("mlp_ratio", 2)
+    d_inner = d * mlp_ratio
+    state_bytes = n_layers * d_inner * n * 4
+
+    print(f"Model: d={d}, L={n_layers}, N={n} | {n_params:,} params | task={task}")
+    print(f"State: {state_bytes:,} bytes ({state_bytes / 1024:.0f} KB) — fixed, never grows")
+    print(f"Measuring {args.tokens} tokens at each context depth (greedy decoding)")
+    print()
+
+    state = RecurrentState(model)
+
+    # Determine start token based on task
+    if task == "lm-tok":
+        import tiktoken
+
+        enc = tiktoken.get_encoding("gpt2")
+        start_token = enc.encode_ordinary("\n")[0]
+    else:
+        start_token = ord("\n")
+
+    # Benchmark at increasing context depths
+    # Feed context tokens first, then measure generation speed
+    context_depths = [0, 100, 1000, 5000, 10000]
+    results = []
+
+    for depth in context_depths:
+        state.reset()
+
+        # Build up context
+        token = start_token
+        for _ in range(depth):
+            logits = state.step(token)
+            token = mx.argmax(logits).item()
+
+        # Measure generation speed at this depth
+        tok_s = benchmark_at_position(state, token, warmup=10, measure=args.tokens)
+        results.append((depth, tok_s))
+        print(f"  After {depth:>6,} tokens of context: {tok_s:,.0f} tok/s")
+
+    print()
+
+    # Show the constant-cost property
+    speeds = [r[1] for r in results]
+    min_s, max_s = min(speeds), max(speeds)
+    variation = (max_s - min_s) / ((max_s + min_s) / 2) * 100
+    print(f"Speed range: {min_s:,.0f} – {max_s:,.0f} tok/s ({variation:.1f}% variation)")
+    print(f"Transformer comparison: KV cache at 10K tokens would use ~{10000 * d * n_layers * 2 * 4 / 1024 / 1024:.0f} MB")
+    print(f"SSM state is always {state_bytes / 1024:.0f} KB regardless of context length")
+
+
+if __name__ == "__main__":
+    main()

--- a/infinite_context.py
+++ b/infinite_context.py
@@ -1,0 +1,136 @@
+"""Infinite context demo: stream a book through the model.
+
+Demonstrates the SSM's constant-memory property by processing an
+arbitrarily long document. Memory never grows — the model compresses
+everything into its fixed state vector.
+
+After processing the full document, generates a continuation to show
+the model "remembers" what it read.
+
+Usage:
+  python infinite_context.py checkpoints/lm --file data/shakespeare.txt
+  python infinite_context.py checkpoints/lm_tok --file data/shakespeare.txt --generate 200
+  python infinite_context.py checkpoints/lm --file data/shakespeare.txt --interval 1000
+"""
+
+import argparse
+import sys
+import time
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from engine import RecurrentState, load_model
+
+
+def get_process_memory_mb():
+    """Get current process RSS in MB (macOS/Linux)."""
+    try:
+        import resource
+
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024 / 1024
+    except Exception:
+        return 0.0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Infinite context demo")
+    parser.add_argument("checkpoint", help="Path to checkpoint directory")
+    parser.add_argument("--file", required=True, help="Text file to stream through the model")
+    parser.add_argument("--generate", type=int, default=200, help="Tokens to generate after reading")
+    parser.add_argument("--interval", type=int, default=5000, help="Print status every N tokens")
+    parser.add_argument("--temp", type=float, default=0.8, help="Sampling temperature for generation")
+    args = parser.parse_args()
+
+    model, config = load_model(args.checkpoint)
+    task = config["task"]
+    d, n_layers, n = config["d_model"], config["n_layers"], config["state_dim"]
+    n_params = sum(x.size for _, x in nn.utils.tree_flatten(model.parameters()))
+    mlp_ratio = config.get("mlp_ratio", 2)
+    d_inner = d * mlp_ratio
+    state_bytes = n_layers * d_inner * n * 4
+
+    # Set up tokenizer for BPE mode
+    enc = None
+    if task == "lm-tok":
+        import tiktoken
+
+        enc = tiktoken.get_encoding("gpt2")
+
+    # Read the input file
+    with open(args.file) as f:
+        text = f.read()
+
+    # Tokenize
+    if enc:
+        tokens = enc.encode_ordinary(text)
+    else:
+        tokens = list(text.encode("utf-8"))
+
+    print(f"Model: d={d}, L={n_layers}, N={n} | {n_params:,} params", file=sys.stderr)
+    print(f"State: {state_bytes:,} bytes ({state_bytes / 1024:.0f} KB) — fixed", file=sys.stderr)
+    print(f"File: {args.file} ({len(text):,} chars, {len(tokens):,} tokens)", file=sys.stderr)
+    print(f"Mode: {'BPE' if enc else 'byte'}", file=sys.stderr)
+    print(file=sys.stderr)
+
+    state = RecurrentState(model)
+    mem_start = get_process_memory_mb()
+
+    # Stream the entire document through the model
+    print(f"{'Tokens':>10}  {'tok/s':>8}  {'State (KB)':>10}  {'RSS (MB)':>10}", file=sys.stderr)
+    print(f"{'------':>10}  {'-----':>8}  {'----------':>10}  {'--------':>10}", file=sys.stderr)
+
+    t0 = time.time()
+    for i, token in enumerate(tokens):
+        logits = state.step(token)
+
+        if (i + 1) % args.interval == 0:
+            elapsed = time.time() - t0
+            tok_s = (i + 1) / elapsed
+            mem_now = get_process_memory_mb()
+            print(
+                f"{i + 1:>10,}  {tok_s:>8,.0f}  {state_bytes / 1024:>10,.0f}  {mem_now:>10,.1f}",
+                file=sys.stderr,
+            )
+
+    elapsed = time.time() - t0
+    tok_s = len(tokens) / elapsed
+    mem_end = get_process_memory_mb()
+
+    print(file=sys.stderr)
+    print(f"Processed {len(tokens):,} tokens in {elapsed:.1f}s ({tok_s:,.0f} tok/s)", file=sys.stderr)
+    print(f"State size: {state_bytes / 1024:.0f} KB (constant throughout)", file=sys.stderr)
+    print(f"RSS: {mem_start:.1f} MB → {mem_end:.1f} MB", file=sys.stderr)
+
+    # Generate continuation
+    if args.generate > 0:
+        print(file=sys.stderr)
+        print(f"--- Generating {args.generate} tokens from the final state ---", file=sys.stderr)
+        print(file=sys.stderr)
+
+        next_token = mx.argmax(logits).item() if args.temp == 0 else _sample(logits, args.temp)
+
+        for _ in range(args.generate):
+            if enc:
+                sys.stdout.write(enc.decode([next_token]))
+            else:
+                sys.stdout.buffer.write(bytes([next_token]))
+            sys.stdout.flush()
+
+            logits = state.step(next_token)
+            next_token = mx.argmax(logits).item() if args.temp == 0 else _sample(logits, args.temp)
+
+        print(file=sys.stderr)
+
+
+def _sample(logits, temperature=0.8, top_k=40):
+    """Sample from logits with temperature and top-k."""
+    logits = logits / temperature
+    if 0 < top_k < logits.shape[-1]:
+        threshold = mx.sort(logits)[-top_k]
+        logits = mx.where(logits < threshold, -1e9, logits)
+    return mx.random.categorical(logits).item()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `benchmark.py`: measures tok/s at context depths 0–10K, proving constant cost per token
- `infinite_context.py`: streams an entire file through the model with constant memory, generates continuation from final state
- README updated with both sections

## Results (d=384, L=4, N=64)
- ~1,100 tok/s, <7% variation across 0–10K context depth
- 768 KB state vs ~117 MB transformer KV cache at 10K tokens
- RSS stays flat while processing 50K+ tokens

## Test plan
- [x] `benchmark.py` shows constant tok/s across context depths
- [x] `infinite_context.py` streams file with constant state size, generates continuation
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)