### PR TITLE
Add --size flag for one-knob model scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ Or reproduce the current best result in one shot:
 bash runs/speedrun.sh    # ~2.17 val_bpb in 84s on M1 Max
 ```
 
+## Model sizes
+
+One flag to scale the model up or down. Default is `small`.
+
+```bash
+uv run python train.py --size tiny     # d=128, L=4   |    662K params | ~30s
+uv run python train.py --size small    # d=384, L=4   |   4.3M params | ~80s (default)
+uv run python train.py --size medium   # d=768, L=6   |  23.4M params
+uv run python train.py --size large    # d=1024, L=12 |  80.9M params
+```
+
+For lm-tok, the 50K vocab embedding adds significant overhead (e.g. `small` = 42.8M params, `large` = 183M). The `NS_*` env vars override any preset for fine-grained control.
+
 ## Generation
 
 Train a model, then generate text from it. Runs in recurrent mode: constant memory, constant cost per token. No KV cache.

--- a/program.md
+++ b/program.md
@@ -58,7 +58,7 @@ Each experiment runs on Apple Silicon via MLX. You launch it as: `uv run python 
 
 **The goal is simple: get the lowest val_bpb** (for language modeling), **highest accuracy** (for DNA), or **lowest val_mse** (for time series). The model is deliberately naive; there are many known improvements to discover.
 
-**Memory** is a soft constraint. Apple Silicon has unified memory (16GB), and an OOM crash kills the whole system. The current model (d=384, L=4, N=64) uses ~42.8M params for lm-tok (mostly the 50K vocab embed+head). You still have headroom — d=512, L=8, N=128 should fit. For lm-tok, note that scaling d_model increases the embed/head tables linearly (50257×d_model each).
+**Memory** is a soft constraint. Apple Silicon has unified memory (16GB), and an OOM crash kills the whole system. Use `--size` to scale the model. The default (`small`, d=384, L=4) uses ~42.8M params for lm-tok. `medium` (d=768, L=6, ~100M lm-tok) should fit comfortably. `large` (d=1024, L=12, ~183M lm-tok) is the upper limit — test with a short run first. For lm-tok, scaling d_model increases the embed/head tables linearly (50257×d_model each), so most params are in the vocab projection.
 
 **Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Removing something and getting equal or better results is a great outcome.
 
@@ -115,11 +115,16 @@ The experiment runs on a dedicated branch (e.g. `autoresearch/mar10`).
 LOOP FOREVER:
 
 1. Look at the git state: the current branch/commit we're on
-2. Decide what to try. Two modes:
-   - **Env var sweep** (for hyperparameter changes): set `NS_*` env vars (NS_D_MODEL, NS_N_LAYERS, NS_STATE_DIM, NS_BATCH_SIZE, NS_LR, NS_STEPS, NS_SEQ_LEN) without editing code. No commit needed.
+2. Decide what to try. Three modes:
+   - **Size preset** (for scaling up/down): use `--size {tiny,small,medium,large}` to change model dimensions in one shot. No code edit needed.
+     - `tiny`: d=128, L=4 (~662K lm, ~13.5M lm-tok) — fast debugging
+     - `small`: d=384, L=4 (~4.3M lm, ~42.8M lm-tok) — default, quick iteration
+     - `medium`: d=768, L=6 (~23M lm, ~100M lm-tok) — serious training
+     - `large`: d=1024, L=12 (~81M lm, ~183M lm-tok) — pushing M1 Max limits
+   - **Env var sweep** (for hyperparameter changes): set `NS_*` env vars (NS_BATCH_SIZE, NS_LR, NS_STEPS, NS_SEQ_LEN) without editing code. `NS_D_MODEL`, `NS_N_LAYERS`, `NS_STATE_DIM` still work and override `--size`. No commit needed.
    - **Code change** (for architectural changes): edit `train.py` and git commit.
-   Use your judgment. Pure number tuning (lr, layer count, dimensions) → env vars. Structural changes (new init, gating, selectivity) → code edit.
-3. Run the experiment: `uv run python train.py --task lm > run.log 2>&1` (redirect everything; do NOT use tee or let output flood your context). Prepend env vars if sweeping, e.g. `NS_LR=3e-4 NS_D_MODEL=256 uv run python train.py --task lm > run.log 2>&1`.
+   Use your judgment. Model scaling → `--size`. Pure number tuning (lr, batch, seq_len) → env vars. Structural changes (new init, gating, selectivity) → code edit.
+3. Run the experiment: `uv run python train.py --task lm > run.log 2>&1` (redirect everything; do NOT use tee or let output flood your context). Use `--size` or prepend env vars if sweeping, e.g. `uv run python train.py --task lm --size medium > run.log 2>&1` or `NS_LR=3e-4 uv run python train.py --task lm > run.log 2>&1`.
 4. Parse the results: `grep -A1 METRICS run.log | head -1` gives a JSON blob with all metrics.
 5. If the output is empty or shows an error, the run crashed. Run `tail -n 50 run.log` to read the stack trace and attempt a fix.
 6. Record the results in results.tsv. For env var sweeps, note the env vars in the description column.
@@ -177,7 +182,7 @@ The model has HiPPO-LegS initialization, Mamba-style gated blocks (pre-norm, SiL
 - Cosine decay min LR: currently decays to 1e-5. For longer runs, the final LR matters more.
 - Gradient accumulation: simulate larger effective batch size without more memory. Accumulate gradients over N steps before updating.
 - Weight decay may help on lm-tok (it hurt on lm where the model was overfitting TinyShakespeare, but lm-tok is in an underfitting regime).
-- Larger/smaller models, different layer counts.
+- Model scaling: use `--size medium` or `--size large` to test bigger models. If an idea works at `small`, validate at `medium` to check scaling.
 
 **Don't be afraid to break things.** The starting model is intentionally basic. Radical changes (replacing the entire SSM core, changing the block structure, adding new components) are encouraged. This is research.
 

--- a/train.py
+++ b/train.py
@@ -8,6 +8,12 @@ Usage:
   python train.py --task lm-tok   # BPE token-level language modeling (FineWebEdu)
   python train.py --task dna      # DNA sequence classification
   python train.py --task ts       # time series forecasting (ETT)
+
+Model sizes (byte-level LM params):
+  python train.py --size tiny     # d=128, L=4   (~662K params)
+  python train.py --size small    # d=384, L=4   (~4.3M params, default)
+  python train.py --size medium   # d=768, L=6   (~23M params)
+  python train.py --size large    # d=1024, L=12 (~81M params)
 """
 
 import argparse
@@ -36,10 +42,19 @@ from data import (
 # Config
 # ---------------------------------------------------------------------------
 
-# model (override via NS_* env vars for sweeps)
-D_MODEL = int(os.environ.get("NS_D_MODEL", 384))
-N_LAYERS = int(os.environ.get("NS_N_LAYERS", 4))
-STATE_DIM = int(os.environ.get("NS_STATE_DIM", 64))
+# Size presets: one knob to scale the model.
+# Use --size {tiny,small,medium,large}. NS_* env vars override any preset.
+SIZE_PRESETS = {
+    "tiny": {"d_model": 128, "n_layers": 4, "state_dim": 64},
+    "small": {"d_model": 384, "n_layers": 4, "state_dim": 64},
+    "medium": {"d_model": 768, "n_layers": 6, "state_dim": 64},
+    "large": {"d_model": 1024, "n_layers": 12, "state_dim": 64},
+}
+
+# model defaults (resolved in main() with --size and NS_* env vars)
+D_MODEL = 384
+N_LAYERS = 4
+STATE_DIM = 64
 MLP_RATIO = 2
 
 # training
@@ -265,11 +280,24 @@ def count_params(model):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--task", choices=["lm", "lm-tok", "dna", "ts"], default="lm")
+    parser.add_argument("--size", choices=list(SIZE_PRESETS), default=None, help="Model size preset (overridden by NS_* env vars)")
     parser.add_argument("--steps", type=int, default=None)
     parser.add_argument("--lr", type=float, default=LEARNING_RATE)
     parser.add_argument("--batch", type=int, default=BATCH_SIZE)
     parser.add_argument("--save", metavar="DIR", help="Save model checkpoint to DIR after training")
     args = parser.parse_args()
+
+    # Resolve model dimensions: defaults < --size < NS_* env vars
+    global D_MODEL, N_LAYERS, STATE_DIM
+    if args.size:
+        p = SIZE_PRESETS[args.size]
+        D_MODEL, N_LAYERS, STATE_DIM = p["d_model"], p["n_layers"], p["state_dim"]
+    if "NS_D_MODEL" in os.environ:
+        D_MODEL = int(os.environ["NS_D_MODEL"])
+    if "NS_N_LAYERS" in os.environ:
+        N_LAYERS = int(os.environ["NS_N_LAYERS"])
+    if "NS_STATE_DIM" in os.environ:
+        STATE_DIM = int(os.environ["NS_STATE_DIM"])
 
     batch_size = args.batch
     task = args.task


### PR DESCRIPTION
## Summary
- Four presets: tiny (662K), small (4.3M, default), medium (23M), large (81M)
- Precedence: defaults < `--size` < `NS_*` env vars — agent workflow unchanged
- program.md updated to guide agent toward `--size` for scaling experiments

## Test plan
- [x] `--size tiny` trains correctly (662K params, 10 steps)
- [x] Default (no `--size`) unchanged (4.3M params)
- [x] `NS_D_MODEL=256 --size tiny` → env var wins (d=256)
- [x] `--size medium` trains correctly (23.4M params)
- [x] `ruff format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)