### PR TITLE
Save best checkpoint during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ For lm-tok, the 50K vocab embedding adds significant overhead (e.g. `small` = 42
 Train a model, then generate text from it. Runs in recurrent mode: constant memory, constant cost per token. No KV cache.
 
 ```bash
-# Train and save a checkpoint
+# Train and save a checkpoint (best model auto-saved to checkpoints/lm/best/)
 uv run python train.py --task lm --save checkpoints/lm
 
-# Generate text
-uv run python generate.py checkpoints/lm --prompt "ROMEO: " --tokens 500
+# Generate from the best checkpoint
+uv run python generate.py checkpoints/lm/best --prompt "ROMEO: " --tokens 500
 
 # Greedy decoding
 uv run python generate.py checkpoints/lm --temp 0 --tokens 200

--- a/program.md
+++ b/program.md
@@ -124,15 +124,15 @@ LOOP FOREVER:
    - **Env var sweep** (for hyperparameter changes): set `NS_*` env vars (NS_BATCH_SIZE, NS_LR, NS_STEPS, NS_SEQ_LEN) without editing code. `NS_D_MODEL`, `NS_N_LAYERS`, `NS_STATE_DIM` still work and override `--size`. No commit needed.
    - **Code change** (for architectural changes): edit `train.py` and git commit.
    Use your judgment. Model scaling → `--size`. Pure number tuning (lr, batch, seq_len) → env vars. Structural changes (new init, gating, selectivity) → code edit.
-3. Run the experiment: `uv run python train.py --task lm > run.log 2>&1` (redirect everything; do NOT use tee or let output flood your context). Use `--size` or prepend env vars if sweeping, e.g. `uv run python train.py --task lm --size medium > run.log 2>&1` or `NS_LR=3e-4 uv run python train.py --task lm > run.log 2>&1`.
+3. Run the experiment: `uv run python train.py --task lm --save checkpoints/lm > run.log 2>&1` (redirect everything; do NOT use tee or let output flood your context). Always use `--save` so the best checkpoint is tracked automatically (saved to `checkpoints/<task>/best/` whenever val_loss improves). Use `--size` or prepend env vars if sweeping, e.g. `uv run python train.py --task lm --size medium --save checkpoints/lm > run.log 2>&1`.
 4. Parse the results: `grep -A1 METRICS run.log | head -1` gives a JSON blob with all metrics.
 5. If the output is empty or shows an error, the run crashed. Run `tail -n 50 run.log` to read the stack trace and attempt a fix.
 6. Record the results in results.tsv. For env var sweeps, note the env vars in the description column.
 7. If the primary metric improved (lower val_bpb, higher accuracy, lower val_mse):
    - **Code change**: keep the commit, advance the branch.
    - **Env var sweep**: commit the winning values as new defaults in `train.py`, then advance.
-   - **Checkpoint**: regenerate the dashboard (`uv run python progress.py --html-only`). Save a checkpoint with `--save checkpoints/<task>_best` (e.g. `checkpoints/lm_best` or `checkpoints/lm_tok_best`). For lm, generate a text sample (`uv run python generate.py checkpoints/lm_best --prompt "ROMEO: " --tokens 200 --temp 0.8 2>&1 | head -20`). For lm-tok, generate with a different prompt (`--prompt "The meaning of life"`). Append the sample to the results log or commit message. Commit results.tsv + reports/, and push to the remote branch.
-   - **Benchmark** (optional, for milestone improvements): Run `uv run python eval.py checkpoints/<task>_best --benchmark hellaswag` to get a standardized HellaSwag score. Log it in the commit message. This only makes sense for lm-tok checkpoints trained for 3K+ steps.
+   - **Checkpoint**: regenerate the dashboard (`uv run python progress.py --html-only`). The best checkpoint was already saved during training (at `checkpoints/<task>/best/`). For lm, generate a text sample (`uv run python generate.py checkpoints/lm/best --prompt "ROMEO: " --tokens 200 --temp 0.8 2>&1 | head -20`). For lm-tok, generate with a different prompt (`--prompt "The meaning of life"`). Append the sample to the results log or commit message. Commit results.tsv + reports/, and push to the remote branch.
+   - **Benchmark** (optional, for milestone improvements): Run `uv run python eval.py checkpoints/lm_tok/best --benchmark hellaswag` to get a standardized HellaSwag score. Log it in the commit message. This only makes sense for lm-tok checkpoints trained for 3K+ steps.
 8. If the metric is equal or worse:
    - **Code change**: git reset back to where you started.
    - **Env var sweep**: nothing to undo, just move on.

--- a/train.py
+++ b/train.py
@@ -358,7 +358,24 @@ def main():
         writer = csv.writer(f)
         writer.writerow(["step", "train_loss", "val_loss"] + extra_cols + ["step_ms", "total_s"])
 
+    # --- checkpoint helper ---
+    def save_checkpoint(path):
+        os.makedirs(path, exist_ok=True)
+        config = {
+            "task": task,
+            "d_model": D_MODEL,
+            "n_layers": N_LAYERS,
+            "state_dim": STATE_DIM,
+            "mlp_ratio": MLP_RATIO,
+        }
+        if task == "lm-tok":
+            config["vocab_size"] = vocab_size
+        model.save_weights(os.path.join(path, "model.npz"))
+        with open(os.path.join(path, "config.json"), "w") as f:
+            json.dump(config, f, indent=2)
+
     # --- train ---
+    best_val_loss = float("inf")
     t0 = time.time()
     for step in range(max_steps):
         ts = time.time()
@@ -403,6 +420,13 @@ def main():
                 row = [step, f"{tl:.4f}", f"{vl:.4f}"] + extra + [f"{step_ms:.0f}", f"{total_s:.1f}"]
                 writer.writerow(row)
 
+            # Save best checkpoint
+            if args.save and vl < best_val_loss:
+                best_val_loss = vl
+                best_path = os.path.join(args.save, "best")
+                save_checkpoint(best_path)
+                print(f"  → new best val_loss={vl:.4f}, saved to {best_path}")
+
     # --- metrics summary (machine-readable) ---
     total_s = time.time() - t0
     summary = {"task": task, "params": n_params, "steps": max_steps, "d_model": D_MODEL, "n_layers": N_LAYERS, "state_dim": STATE_DIM}
@@ -418,22 +442,12 @@ def main():
         summary["val_mse"] = round(metrics["val_mse"], 4)
         summary["val_mae"] = round(metrics["val_mae"], 4)
 
-    # --- checkpoint ---
+    # --- checkpoint (final) ---
     if args.save:
-        os.makedirs(args.save, exist_ok=True)
-        config = {
-            "task": task,
-            "d_model": D_MODEL,
-            "n_layers": N_LAYERS,
-            "state_dim": STATE_DIM,
-            "mlp_ratio": MLP_RATIO,
-        }
-        if task == "lm-tok":
-            config["vocab_size"] = vocab_size
-        model.save_weights(os.path.join(args.save, "model.npz"))
-        with open(os.path.join(args.save, "config.json"), "w") as f:
-            json.dump(config, f, indent=2)
+        save_checkpoint(args.save)
         print(f"Saved checkpoint to {args.save}")
+        if best_val_loss < float("inf"):
+            print(f"Best checkpoint (val_loss={best_val_loss:.4f}) at {args.save}/best")
 
     print(f"\nDone. Log: {log_file}")
     print("---METRICS---")


### PR DESCRIPTION
## Summary
- Auto-saves model with lowest val_loss to `{save_dir}/best/` during training
- Final checkpoint still saved to `{save_dir}/` as before
- Extracted `save_checkpoint()` helper to avoid duplication
- Updated program.md: agent always uses `--save`, references `checkpoints/<task>/best/`
- Updated README generation example to use best checkpoint

## Test plan
- [x] `--save /tmp/test` produces both `/tmp/test/model.npz` and `/tmp/test/best/model.npz`
- [x] Best checkpoint loads correctly with `generate.py`
- [x] "new best" printed only when val_loss improves
- [x] No `--save` → no checkpoint behavior (unchanged)
- [x] `ruff format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)